### PR TITLE
Support the load_current_consents parameter to the member details endpoint

### DIFF
--- a/lib/identity-api-client/member.rb
+++ b/lib/identity-api-client/member.rb
@@ -1,7 +1,10 @@
 module IdentityApiClient
   class Member < Base
-    def details(guid)
+    def details(guid, load_current_consents: false)
       params = {'guid' => guid, 'api_token' => client.connection.configuration.options[:api_token]}
+      if load_current_consents
+        params['load_current_consents'] = true
+      end
 
       resp = client.post_request('/api/member/details', params)
       resp.body

--- a/spec/fixtures/details_with_consents.json
+++ b/spec/fixtures/details_with_consents.json
@@ -1,0 +1,18 @@
+{
+  "first_name": "Joe",
+  "last_name": "Bloggs",
+  "email": "joe@bloggs.com",
+
+  "consents": [
+    {
+      "public_id": "terms_of_service_1.0",
+      "consent_level": "explicit_opt_in",
+      "consent_created_at": "2016-12-30 23:30:13 +0000"
+    },
+    {
+      "public_id": "privacy_policy_2.6",
+      "consent_level": "implicit",
+      "consent_created_at": "2015-01-01 10:10:10 +0000"
+    }
+  ]
+}

--- a/spec/fixtures/request.json
+++ b/spec/fixtures/request.json
@@ -1,1 +1,0 @@
-{"guid":"abcdef1234567890","api_token":"1234567890abcdef"}

--- a/spec/member_spec.rb
+++ b/spec/member_spec.rb
@@ -4,23 +4,42 @@ describe IdentityApiClient::Member do
   subject { IdentityApiClient.new(host: 'test.com', api_token: '1234567890abcdef') }
 
   let(:request_path) { '/api/member/details' }
-  let(:request_body) { fixture('request.json').chomp }
 
   describe 'success' do
     let(:status) { 200 }
-    let(:body) { fixture('details.json') }
 
     before(:each) do
-      stub_post(request_path).with(body: request_body).to_return(:body => body, :status => status,
-                                                                 :headers => {:content_type => "application/json; charset=utf-8"})
+      stub_post(request_path).with(body: expected_request).to_return(:body => body, :status => status,
+                                                                     :headers => {:content_type => "application/json; charset=utf-8"})
     end
 
-    it 'should get member details back from the API' do
-      resp = subject.member.details('abcdef1234567890')
+    context 'without load_current_consents' do
+      let(:expected_request) { {'guid' => 'abcdef1234567890', 'api_token' => '1234567890abcdef'}.to_json }
+      let(:body) { fixture('details.json') }
 
-      expect(resp.first_name).to eq('Joe')
-      expect(resp.last_name).to eq('Bloggs')
-      expect(resp.email).to eq('joe@bloggs.com')
+      it 'should get member details back from the API' do
+        resp = subject.member.details('abcdef1234567890')
+
+        expect(resp.first_name).to eq('Joe')
+        expect(resp.last_name).to eq('Bloggs')
+        expect(resp.email).to eq('joe@bloggs.com')
+      end
+    end
+
+    context 'with load_current_consents' do
+      let(:expected_request) { {'guid' => 'abcdef1234567890', 'api_token' => '1234567890abcdef', 'load_current_consents' => true}.to_json }
+      let(:body) { fixture('details_with_consents.json') }
+
+      it 'should get member details with consents back from the API' do
+        resp = subject.member.details('abcdef1234567890', load_current_consents: true)
+
+        expect(resp.first_name).to eq('Joe')
+        expect(resp.last_name).to eq('Bloggs')
+        expect(resp.email).to eq('joe@bloggs.com')
+
+        expect(resp.consents.count).to eq 2
+        expect(resp.consents[0].public_id).to eq 'terms_of_service_1.0'
+      end
     end
   end
 end


### PR DESCRIPTION
This updates the `IdentityApiClient::Member#details` method to support an optional `load_current_consents` parameter. If this parameter is true, it will be included in the Identity call.